### PR TITLE
missing dependency in msgs

### DIFF
--- a/ros_typedb_msgs/package.xml
+++ b/ros_typedb_msgs/package.xml
@@ -16,6 +16,8 @@
   <exec_depend>rosidl_default_runtime</exec_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>
 
+  <depend>rcl_interfaces</depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
This missing dependency broke the generation of java code from the msgs in my usage, since it was not importing rcl_interfaces as necessary.