### PR TITLE
remove try/except when loading data to allow exception to propagate

### DIFF
--- a/ros_typedb/ros_typedb/typedb_interface.py
+++ b/ros_typedb/ros_typedb/typedb_interface.py
@@ -359,14 +359,11 @@ class TypeDBInterface:
         :param force: if database should be overwritten.
         """
         if data_path is not None and data_path != '':
-            try:
-                self.write_database_file(
-                    SessionType.DATA,
-                    'insert',
-                    data_path
-                )
-            except Exception as err:
-                print('Error in load_data method. Exception msg: ', err)
+            self.write_database_file(
+                SessionType.DATA,
+                'insert',
+                data_path
+            )
 
     # Events begining
     def insert_data_event(self):

--- a/ros_typedb/test/test_ros_typedb_interface.py
+++ b/ros_typedb/test/test_ros_typedb_interface.py
@@ -116,6 +116,37 @@ def test_node():
         node.destroy_node()
 
 
+@launch_pytest.fixture
+def generate_test_description_bad_data():
+    path_to_test = Path(__file__).parents[1]
+    path_tql = path_to_test / 'test' / 'typedb_test_data'
+
+    ros_typedb_node = launch_ros.actions.Node(
+        executable=sys.executable,
+        arguments=[
+            str(path_to_test / 'ros_typedb' / 'ros_typedb_node.py')],
+        additional_env={'PYTHONUNBUFFERED': '1'},
+        name='ros_typedb',
+        output='screen',
+        parameters=[{
+            'schema_path': [str(path_tql / 'schema.tql')],
+            'data_path': [str(path_tql / 'bad_data.tql')],
+            'database_name': 'ros_typedb_bad_data_test',
+        }]
+    )
+
+    return launch.LaunchDescription([
+        ros_typedb_node,
+    ])
+
+
+@pytest.mark.launch(fixture=generate_test_description_bad_data)
+def test_ros_typedb_configure_bad_data(test_node):
+    """Regression: configure must fail when data_path contains invalid TypeQL."""
+    configure_res = test_node.change_ros_typedb_state(1)
+    assert configure_res.success is False
+
+
 @pytest.mark.launch(fixture=generate_test_description)
 def test_ros_typedb_lc_states(test_node):
     configure_res = test_node.change_ros_typedb_state(1)

--- a/ros_typedb/test/test_typedb_interface.py
+++ b/ros_typedb/test/test_typedb_interface.py
@@ -34,6 +34,12 @@ def typedb_interface():
     typedb_interface.delete_database()
 
 
+def test_load_bad_data_raises(typedb_interface):
+    """Regression: load_data must raise on invalid TypeQL, not silently pass."""
+    with pytest.raises(Exception):
+        typedb_interface.load_data('test/typedb_test_data/bad_data.tql')
+
+
 def test_create_and_delete_database():
     typedb_interface = TypeDBInterface(
         'localhost:1729',

--- a/ros_typedb/test/typedb_test_data/bad_data.tql
+++ b/ros_typedb/test/typedb_test_data/bad_data.tql
@@ -1,0 +1,1 @@
+$bad_entity isa person;


### PR DESCRIPTION
@EGAlberts FYI. In case you run into ros_typedb crashing due to bad data. I think it is better that it fails loading bad data than silently failing.