### PR TITLE
[codex] Add TypeDB driver connection timeout

### DIFF
--- a/ros_typedb/ros_typedb/ros_typedb_interface.py
+++ b/ros_typedb/ros_typedb/ros_typedb_interface.py
@@ -312,6 +312,7 @@ class ROSTypeDBInterface(Node):
         self.declare_parameter('force_database', True)
         self.declare_parameter('force_data', True)
         self.declare_parameter('infer', True)
+        self.declare_parameter('driver_timeout_s', 10.0)
 
         self.default_schema_path = ''
         self.declare_parameter('schema_path', [''])
@@ -332,7 +333,8 @@ class ROSTypeDBInterface(Node):
             force_database: Optional[bool] = False,
             force_data: Optional[bool] = False,
             infer: Optional[bool] = False,
-            sort_fetch_results: Optional[bool] = False) -> None:
+            sort_fetch_results: Optional[bool] = False,
+            driver_timeout_s: Optional[float] = 10.0) -> None:
         """
         Initialize self.typedb_interface.
 
@@ -343,7 +345,10 @@ class ROSTypeDBInterface(Node):
         :param force_database: if database should override an existing database
         :param force_data: if the database data should be overriden.
         :param infer: if inference engine should be used.
-        :param sort_fetch_results: if fetch query results should be recursively sorted.
+        :param sort_fetch_results: if fetch query results should be
+            recursively sorted.
+        :param driver_timeout_s: seconds to wait for driver connection before
+            timing out.
         """
         self.typedb_interface = self.typedb_interface_class(
             address,
@@ -353,7 +358,8 @@ class ROSTypeDBInterface(Node):
             force_database,
             force_data,
             infer,
-            sort_fetch_results
+            sort_fetch_results,
+            driver_timeout_s
         )
 
         self.typedb_interface.insert_data_event = self.insert_data_event
@@ -391,7 +397,8 @@ class ROSTypeDBInterface(Node):
             force_database=self.get_parameter('force_database').value,
             force_data=self.get_parameter('force_data').value,
             infer=self.get_parameter('infer').value,
-            sort_fetch_results=self.get_parameter('sort_fetch_results').value
+            sort_fetch_results=self.get_parameter('sort_fetch_results').value,
+            driver_timeout_s=self.get_parameter('driver_timeout_s').value
         )
 
         self.event_pub = self.create_lifecycle_publisher(

--- a/ros_typedb/ros_typedb/typedb_interface.py
+++ b/ros_typedb/ros_typedb/typedb_interface.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 """typedb_interface - python interface to interact with typedb."""
 
-from datetime import datetime
 import functools
 import logging
+import queue
+import threading
+from datetime import datetime
 from types import MethodType
 from typing import Iterator
 from typing import Literal
@@ -148,7 +150,8 @@ class TypeDBInterface:
             force_database: Optional[bool] = False,
             force_data: Optional[bool] = False,
             infer: Optional[bool] = False,
-            sort_fetch_results: Optional[bool] = False) -> None:
+            sort_fetch_results: Optional[bool] = False,
+            driver_timeout_s: Optional[float] = 10.0) -> None:
         """
         Connect to a typeDB server and interacts with it.
 
@@ -163,12 +166,16 @@ class TypeDBInterface:
         :param force_database: if database should override an existing database
         :param force_data: if the database data should be overriden.
         :param infer: if inference engine should be used.
-        :param sort_fetch_results: if fetch query results should be recursively sorted.
+        :param sort_fetch_results: if fetch query results should be
+            recursively sorted.
+        :param driver_timeout_s: seconds to wait for driver connection before
+            timing out.
+            Set to None or a non-positive value to wait without a timeout.
         """
         self.logger = logging.getLogger()
         self._infer = infer
         self._sort_fetch_results = bool(sort_fetch_results)
-        self.connect_driver(address)
+        self.connect_driver(address, timeout_s=driver_timeout_s)
         self.create_database(database_name, force=force_database)
         if isinstance(schema_path, str):
             schema_path = string_to_string_array(schema_path)
@@ -210,13 +217,56 @@ class TypeDBInterface:
         """
         setattr(self, name, MethodType(func, self))
 
-    def connect_driver(self, address: str) -> None:
+    def connect_driver(
+            self,
+            address: str,
+            timeout_s: Optional[float] = 10.0) -> None:
         """
         Connect to typedb server.
 
         :param address: typedb server address.
+        :param timeout_s: seconds to wait for driver connection before
+            timing out.
+            Set to None or a non-positive value to wait without a timeout.
         """
-        self.driver = TypeDB.core_driver(address=address)
+        if timeout_s is None:
+            self.driver = TypeDB.core_driver(address=address)
+            return
+
+        try:
+            timeout_s = float(timeout_s)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                'driver_timeout_s must be a number, None, or non-positive'
+            ) from exc
+
+        if timeout_s <= 0:
+            self.driver = TypeDB.core_driver(address=address)
+            return
+
+        result_queue = queue.Queue(maxsize=1)
+
+        def connect_driver_thread():
+            try:
+                result_queue.put((True, TypeDB.core_driver(address=address)))
+            except BaseException as exc:  # noqa: B902
+                result_queue.put((False, exc))
+
+        thread = threading.Thread(target=connect_driver_thread, daemon=True)
+        thread.start()
+        thread.join(timeout=timeout_s)
+
+        if thread.is_alive():
+            raise TimeoutError(
+                f'Timed out connecting to TypeDB at {address} after '
+                f'{timeout_s:g} seconds'
+            )
+
+        succeeded, result = result_queue.get_nowait()
+        if succeeded:
+            self.driver = result
+        else:
+            raise result
 
     def delete_database(self, database_name: str = None) -> None:
         """

--- a/ros_typedb/ros_typedb/typedb_interface.py
+++ b/ros_typedb/ros_typedb/typedb_interface.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 """typedb_interface - python interface to interact with typedb."""
 
+from datetime import datetime
 import functools
 import logging
 import queue
 import threading
-from datetime import datetime
 from threading import Lock
 from types import MethodType
 from typing import Iterator

--- a/ros_typedb/test/test_typedb_interface.py
+++ b/ros_typedb/test/test_typedb_interface.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 from datetime import datetime
+import time
 
 import pytest
 

--- a/ros_typedb/test/test_typedb_interface.py
+++ b/ros_typedb/test/test_typedb_interface.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
 from datetime import datetime
 
 import pytest
@@ -38,6 +39,26 @@ def test_load_bad_data_raises(typedb_interface):
     """Regression: load_data must raise on invalid TypeQL, not silently pass."""
     with pytest.raises(Exception):
         typedb_interface.load_data('test/typedb_test_data/bad_data.tql')
+
+
+def test_driver_connection_timeout(monkeypatch):
+    def slow_core_driver(address):
+        time.sleep(1.0)
+
+    monkeypatch.setattr(
+        'ros_typedb.typedb_interface.TypeDB.core_driver',
+        slow_core_driver
+    )
+
+    start_time = time.monotonic()
+    with pytest.raises(TimeoutError):
+        TypeDBInterface(
+            'localhost:1729',
+            'test_database',
+            driver_timeout_s=0.01
+        )
+
+    assert time.monotonic() - start_time < 0.5
 
 
 def test_create_and_delete_database():


### PR DESCRIPTION
## Summary

Fixes #36.

Adds a configurable timeout around `TypeDB.core_driver(address=address)` so `TypeDBInterface` raises `TimeoutError` instead of waiting indefinitely when driver connection hangs. The default timeout is 10 seconds, and callers can set `driver_timeout_s` to `None` or a non-positive value to keep the previous unbounded wait behavior.

The ROS lifecycle node now declares and forwards a `driver_timeout_s` parameter, so launch/runtime users can tune the timeout without code changes.

## Validation

- `python3 -m py_compile src/ros_typedb/ros_typedb/ros_typedb/typedb_interface.py src/ros_typedb/ros_typedb/ros_typedb/ros_typedb_interface.py src/ros_typedb/ros_typedb/test/test_typedb_interface.py`
- `git -C src/ros_typedb diff --check`

Could not run the focused pytest on the host because the installed host `typedb` package cannot import `ConceptMap`; the documented `suave_rebetmc` container was not running locally.