### PR TITLE
Fix TypeQL string literal escaping and use converter in delete_thing

### DIFF
--- a/ros_typedb/ros_typedb/typedb_interface.py
+++ b/ros_typedb/ros_typedb/typedb_interface.py
@@ -80,7 +80,14 @@ def convert_py_type_to_query_type(
     """
     if isinstance(data, str):
         if len(data) > 0 and data[0] != '$':
-            return "'{}'".format(data)
+            escaped_data = (
+                data.replace('\\', '\\\\')
+                .replace("'", "\\'")
+                .replace('\n', '\\n')
+                .replace('\r', '\\r')
+                .replace('\t', '\\t')
+            )
+            return "'{}'".format(escaped_data)
     elif isinstance(data, datetime):
         return data.isoformat(timespec='milliseconds')
     elif isinstance(data, bool):
@@ -966,8 +973,9 @@ class TypeDBInterface:
         :param key_value: attribute value to identify the individual.
         :return: True.
         """
+        key_value = convert_py_type_to_query_type(key_value)
         query = f"""
-            match $thing isa {thing}, has {key} "{key_value}";
+            match $thing isa {thing}, has {key} {key_value};
             delete $thing isa {thing};
         """
         return self.delete_from_database(query)

--- a/ros_typedb/test/test_typedb_interface.py
+++ b/ros_typedb/test/test_typedb_interface.py
@@ -37,7 +37,7 @@ def typedb_interface():
 
 
 def test_convert_py_type_to_query_type_escapes_strings():
-    assert convert_py_type_to_query_type('O\'Brien') == "'O\\'Brien'"
+    assert convert_py_type_to_query_type("O'Brien") == "'O\\'Brien'"
     assert convert_py_type_to_query_type(r'C:\\tmp') == r"'C:\\\\tmp'"
     assert convert_py_type_to_query_type('$person') == '$person'
 

--- a/ros_typedb/test/test_typedb_interface.py
+++ b/ros_typedb/test/test_typedb_interface.py
@@ -37,8 +37,8 @@ def typedb_interface():
 
 
 def test_convert_py_type_to_query_type_escapes_strings():
-    assert convert_py_type_to_query_type("O'Brien") == "'O\\'Brien'"
-    assert convert_py_type_to_query_type(r"C:\\tmp") == r"'C:\\\\tmp'"
+    assert convert_py_type_to_query_type('O\'Brien') == "'O\\'Brien'"
+    assert convert_py_type_to_query_type(r'C:\\tmp') == r"'C:\\\\tmp'"
     assert convert_py_type_to_query_type('$person') == '$person'
 
 

--- a/ros_typedb/test/test_typedb_interface.py
+++ b/ros_typedb/test/test_typedb_interface.py
@@ -17,6 +17,7 @@ import time
 
 import pytest
 
+from ros_typedb.typedb_interface import convert_py_type_to_query_type
 from ros_typedb.typedb_interface import TypeDBInterface
 
 
@@ -33,6 +34,29 @@ def typedb_interface():
     )
     yield typedb_interface
     typedb_interface.delete_database()
+
+
+def test_convert_py_type_to_query_type_escapes_strings():
+    assert convert_py_type_to_query_type("O'Brien") == "'O\\'Brien'"
+    assert convert_py_type_to_query_type(r"C:\\tmp") == r"'C:\\\\tmp'"
+    assert convert_py_type_to_query_type('$person') == '$person'
+
+
+def test_delete_thing_uses_query_type_conversion(monkeypatch):
+    typedb_interface = TypeDBInterface.__new__(TypeDBInterface)
+    captured_query = None
+
+    def fake_delete_from_database(query):
+        nonlocal captured_query
+        captured_query = query
+        return True
+
+    monkeypatch.setattr(
+        typedb_interface, 'delete_from_database', fake_delete_from_database)
+
+    assert typedb_interface.delete_thing('person', 'name', "O'Brien") is True
+    assert "has name 'O\\'Brien'" in captured_query
+    assert 'has name "O\'Brien"' not in captured_query
 
 
 def test_load_bad_data_raises(typedb_interface):


### PR DESCRIPTION
### Motivation
- The Python→TypeQL string conversion did not escape single quotes or backslashes, causing queries to break for values like `O'Brien` and creating an injection-like surface. 
- `delete_thing()` constructed its match clause with hard-coded double quotes and bypassed the shared conversion path, making its behavior inconsistent with other query builders. 

### Description
- Escape string literals in `convert_py_type_to_query_type()` by escaping backslashes, single quotes, and common control characters before wrapping in single quotes, while preserving TypeQL variables that begin with `$` (file: `ros_typedb/ros_typedb/typedb_interface.py`).
- Change `delete_thing()` to call `convert_py_type_to_query_type()` for `key_value` and insert the converted token into the query instead of hard-coded double-quote wrapping (file: `ros_typedb/ros_typedb/typedb_interface.py`).
- Add two regression unit tests to `ros_typedb/test/test_typedb_interface.py` that assert the escaping behavior of `convert_py_type_to_query_type()` and that `delete_thing()` uses the converter when building the query. 

### Testing
- Compiled modified modules with `python3 -m py_compile ros_typedb/ros_typedb/typedb_interface.py ros_typedb/test/test_typedb_interface.py`, which succeeded. 
- Attempted to run the new unit tests with `PYTHONPATH=ros_typedb pytest ros_typedb/test/test_typedb_interface.py::test_convert_py_type_to_query_type_escapes_strings ros_typedb/test/test_typedb_interface.py::test_delete_thing_uses_query_type_conversion`, but the run is blocked in this environment because the installed TypeDB native driver requires `libpython3.13.so.1.0` while the active interpreter is Python 3.14, so pytest could not execute against the TypeDB client (environment failure, not code failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dcba7e1d4832c9965d6442c85808a)