### PR TITLE
Fix logging format for TypeDB warnings to include exceptions and database name

### DIFF
--- a/ros_typedb/ros_typedb/typedb_interface.py
+++ b/ros_typedb/ros_typedb/typedb_interface.py
@@ -295,9 +295,9 @@ class TypeDBInterface:
         self.database_name = database_name
         if self.driver.databases.contains(database_name):
             self.logger.warning(
-                'The database with the name ',
-                database_name,
-                ' already exists. Ignoring create_database request.')
+                'The database with the name %s already exists. '
+                'Ignoring create_database request.',
+                database_name)
             return
 
         self.driver.databases.create(database_name)
@@ -463,7 +463,8 @@ class TypeDBInterface:
             result = self.database_query(
                 SessionType.DATA, TransactionType.WRITE, 'insert', query)
         except Exception as err:
-            self.logger.warning('Error with insert query! Exception retrieved: ', err)
+            self.logger.warning(
+                'Error with insert query! Exception retrieved: %s', err)
         return result
 
     def update_database(self, query: str) -> Iterator[ConceptMap] | None:
@@ -478,7 +479,8 @@ class TypeDBInterface:
             result = self.database_query(
                 SessionType.DATA, TransactionType.WRITE, 'update', query)
         except Exception as err:
-            self.logger.warning('Error with update query! Exception retrieved: ', err)
+            self.logger.warning(
+                'Error with update query! Exception retrieved: %s', err)
         return result
 
     # @delete_data_event_
@@ -494,7 +496,8 @@ class TypeDBInterface:
             result = self.database_query(
                 SessionType.DATA, TransactionType.WRITE, 'delete', query)
         except Exception as err:
-            self.logger.warning('Error with delete query! Exception retrieved: ', err)
+            self.logger.warning(
+                'Error with delete query! Exception retrieved: %s', err)
         return result
 
     def fetch_database(
@@ -566,7 +569,7 @@ class TypeDBInterface:
                 options)
         except Exception as err:
             self.logger.warning(
-                'Error with get query! Exception retrieved: ', err)
+                'Error with get query! Exception retrieved: %s', err)
         return result
 
     def get_aggregate_database(self, query: str) -> int | float | None:
@@ -588,7 +591,7 @@ class TypeDBInterface:
                 options)
         except Exception as err:
             self.logger.warning(
-                'Error with get_aggregate query! Exception retrieved: ', err)
+                'Error with get_aggregate query! Exception retrieved: %s', err)
         return result
     # Read/write database end
 


### PR DESCRIPTION
### Motivation
- Correct improper `logging` usage where exception objects and the database name were passed as extra positional args and thus dropped from emitted logs, causing real errors and values not to appear in log output.

### Description
- Update `ros_typedb/ros_typedb/typedb_interface.py` to use printf-style placeholders (`%s`) for exception messages in `insert`, `update`, `delete`, `get`, and `get_aggregate` warning logs.
- Consolidate the `create_database()` warning into a single format string using `%s` so the database name is included in the log message.
- Reformat the affected `logger.warning` calls for readability while preserving semantics.

### Testing
- `python -m py_compile ros_typedb/ros_typedb/typedb_interface.py` succeeded.
- `git diff --check` succeeded.
- `PYTHONPATH=/workspace/ros_typedb/ros_typedb pytest ros_typedb/test/test_typedb_interface.py` could not complete collection because the installed TypeDB native wrapper requires `libpython3.13.so.1.0`, which is not available in the current Python 3.14 environment.
- `PYTHONPATH=/workspace/ros_typedb/ros_typedb pytest ros_typedb/test/test_flake8.py` could not complete collection because `ament_flake8` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dcbbfe04c832cb4db386d845e8340)