### PR TITLE
Fix query result index overflow (uint8 -> uint32)

### DIFF
--- a/ros_typedb/test/test_ros_typedb_interface.py
+++ b/ros_typedb/test/test_ros_typedb_interface.py
@@ -493,7 +493,6 @@ def test_fetch_result_to_ros_result_tree():
 
     assert expected_tree == result_tree
 
-
     json_test = {
         'company_var': {
             'address': [
@@ -774,7 +773,6 @@ def test_fetch_result_to_ros_result_tree():
 
 
 @pytest.mark.launch(fixture=generate_test_description)
-
 def test_ros_typedb_fetch_query_attribute(test_node, insert_query):
     test_node.activate_ros_typedb()
 

--- a/ros_typedb/test/test_ros_typedb_interface.py
+++ b/ros_typedb/test/test_ros_typedb_interface.py
@@ -147,6 +147,29 @@ def test_ros_typedb_configure_bad_data(test_node):
     assert configure_res.success is False
 
 
+def test_fetch_result_to_ros_result_tree_accepts_more_than_uint8_indices():
+    json_test = {
+        f'attr_{index}': {
+            'value': index,
+            'type': {
+                'label': 'age',
+                'root': 'attribute',
+                'value_type': 'long'}}
+        for index in range(260)
+    }
+
+    result_tree, tree_index = fetch_result_to_ros_result_tree(json_test)
+
+    assert len(result_tree.results) == 260
+    assert tree_index == 260
+    assert result_tree.results[255].result_index == 255
+    assert result_tree.results[256].result_index == 256
+
+    index_list = IndexList()
+    index_list.index = list(range(260))
+    assert index_list.index[256] == 256
+
+
 @pytest.mark.launch(fixture=generate_test_description)
 def test_ros_typedb_lc_states(test_node):
     configure_res = test_node.change_ros_typedb_state(1)
@@ -470,6 +493,7 @@ def test_fetch_result_to_ros_result_tree():
 
     assert expected_tree == result_tree
 
+
     json_test = {
         'company_var': {
             'address': [
@@ -750,6 +774,7 @@ def test_fetch_result_to_ros_result_tree():
 
 
 @pytest.mark.launch(fixture=generate_test_description)
+
 def test_ros_typedb_fetch_query_attribute(test_node, insert_query):
     test_node.activate_ros_typedb()
 

--- a/ros_typedb_msgs/msg/IndexList.msg
+++ b/ros_typedb_msgs/msg/IndexList.msg
@@ -1,1 +1,1 @@
-uint8[] index
+uint32[] index

--- a/ros_typedb_msgs/msg/QueryResult.msg
+++ b/ros_typedb_msgs/msg/QueryResult.msg
@@ -4,7 +4,7 @@ uint8 SUB_QUERY = 3
 
 uint8 type  # THING, ATTRIBUTE, or SUB_QUERY
 
-uint8 result_index  # The index of the result in the ResultTree
+uint32 result_index  # The index of the result in the ResultTree
 ros_typedb_msgs/IndexList[] children_index  # The index of this QueryResult children in the ResultTree. This is only useful for SUB_QUERY results
 
 ros_typedb_msgs/Thing thing  # Should only be set when type is THING


### PR DESCRIPTION
### Motivation
- The result index fields were declared as `uint8`, which overflows when a flattened fetch result contains more than 255 nodes and causes `AssertionError`/`OverflowError` during rclpy integer validation.

### Description
- Change `QueryResult.result_index` from `uint8` to `uint32` in `ros_typedb_msgs/msg/QueryResult.msg`.
- Change `IndexList.index` from `uint8[]` to `uint32[]` in `ros_typedb_msgs/msg/IndexList.msg`.
- Add regression test `test_fetch_result_to_ros_result_tree_accepts_more_than_uint8_indices` in `ros_typedb/test/test_ros_typedb_interface.py` that constructs 260 flattened results and verifies `result_index` and `IndexList.index` values beyond 255.

### Testing
- Ran `git diff --check` with no issues found.
- Ran a small Python assertion script verifying `QueryResult.msg` and `IndexList.msg` now contain `uint32` (passed).
- Attempted `pytest ros_typedb/test/test_ros_typedb_interface.py -q`, but test collection failed in this environment because the ROS `launch` Python package is not installed, so the full test suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dcbd737dc832c91aa3b7aea106640)