### PR TITLE
Close TypeDB driver on configure failure

### DIFF
--- a/ros_typedb/ros_typedb/ros_typedb_interface.py
+++ b/ros_typedb/ros_typedb/ros_typedb_interface.py
@@ -367,6 +367,15 @@ class ROSTypeDBInterface(Node):
         self.typedb_interface.insert_data_event = self.insert_data_event
         self.typedb_interface.delete_data_event = self.delete_data_event
 
+    def close_typedb_interface(self) -> None:
+        """Close the TypeDB driver if the interface was initialized."""
+        typedb_interface = getattr(self, 'typedb_interface', None)
+        driver = getattr(typedb_interface, 'driver', None)
+        if driver is not None:
+            driver.close()
+        if typedb_interface is not None:
+            self.typedb_interface = None
+
     def publish_data_event(self, event_type: str) -> None:
         """
         Publish message in the `/event` topic.
@@ -425,6 +434,13 @@ class ROSTypeDBInterface(Node):
                 self.delete_db_cb,
                 callback_group=self.query_cb_group)
         except Exception as exc:
+            try:
+                self.close_typedb_interface()
+            except Exception:
+                self.get_logger().error(
+                    self.get_name() +
+                    ': failed to close TypeDB interface after configure '
+                    'failure:\n' + traceback.format_exc())
             self.get_logger().error(
                 self.get_name() + ': on_configure() failed: ' + str(exc) +
                 '\n' + traceback.format_exc())

--- a/ros_typedb/test/test_ros_typedb_interface.py
+++ b/ros_typedb/test/test_ros_typedb_interface.py
@@ -32,6 +32,7 @@ from rclpy.node import Node
 
 from ros_typedb.ros_typedb_interface import convert_attribute_dict_to_ros_msg
 from ros_typedb.ros_typedb_interface import fetch_result_to_ros_result_tree
+from ros_typedb.ros_typedb_interface import ROSTypeDBInterface
 
 from ros_typedb_msgs.msg import Attribute
 from ros_typedb_msgs.msg import IndexList
@@ -114,6 +115,32 @@ def test_node():
     finally:
         node.delete_dabase()
         node.destroy_node()
+
+
+class MockTypeDBDriver:
+
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class MockTypeDBInterface:
+
+    def __init__(self):
+        self.driver = MockTypeDBDriver()
+
+
+def test_close_typedb_interface_closes_driver_and_clears_reference():
+    ros_typedb_interface = ROSTypeDBInterface.__new__(ROSTypeDBInterface)
+    typedb_interface = MockTypeDBInterface()
+    ros_typedb_interface.typedb_interface = typedb_interface
+
+    ros_typedb_interface.close_typedb_interface()
+
+    assert typedb_interface.driver.closed is True
+    assert ros_typedb_interface.typedb_interface is None
 
 
 @launch_pytest.fixture


### PR DESCRIPTION
### Motivation
- Fix a lifecycle bug where `on_configure` can leave a partially-initialized TypeDB driver open when `init_typedb_interface` succeeds but a later step (e.g., `create_service`) raises, which caused driver leaks on subsequent configure retries.

### Description
- Add `close_typedb_interface()` to `ROSTypeDBInterface` which closes the underlying TypeDB `driver` if present and clears the `typedb_interface` reference.
- Call `close_typedb_interface()` from the `except` handler in `on_configure` to ensure partial state is cleaned up on configure failure and log any cleanup failure separately.
- Add a unit test `test_close_typedb_interface_closes_driver_and_clears_reference` that uses a small mock `MockTypeDBInterface`/`MockTypeDBDriver` to verify the driver is closed and the reference is cleared.

### Testing
- `python3 -m py_compile ros_typedb/ros_typedb/ros_typedb_interface.py ros_typedb/test/test_ros_typedb_interface.py` succeeded.
- `pytest ros_typedb/test/test_ros_typedb_interface.py::test_close_typedb_interface_closes_driver_and_clears_reference` could not be executed in this environment due to a missing ROS launch dependency (`ModuleNotFoundError: No module named 'launch'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dcc195a30832c9ed706c3a62bbe28)