### PR TITLE
Fix TypeDB driver cleanup on lifecycle cleanup

### DIFF
--- a/ros_typedb/ros_typedb/ros_typedb_interface.py
+++ b/ros_typedb/ros_typedb/ros_typedb_interface.py
@@ -367,6 +367,15 @@ class ROSTypeDBInterface(Node):
         self.typedb_interface.insert_data_event = self.insert_data_event
         self.typedb_interface.delete_data_event = self.delete_data_event
 
+    def close_typedb_interface(self) -> None:
+        """Close the TypeDB driver if the interface was initialized."""
+        typedb_interface = getattr(self, 'typedb_interface', None)
+        driver = getattr(typedb_interface, 'driver', None)
+        if driver is not None:
+            driver.close()
+        if typedb_interface is not None:
+            self.typedb_interface = None
+
     def publish_data_event(self, event_type: str) -> None:
         """
         Publish message in the `/event` topic.
@@ -449,13 +458,7 @@ class ROSTypeDBInterface(Node):
             self.destroy_publisher(self.event_pub)
             del self.event_pub
 
-        typedb_interface = getattr(self, 'typedb_interface', None)
-        if typedb_interface is not None:
-            driver = getattr(typedb_interface, 'driver', None)
-            if driver is not None:
-                driver.close()
-                del typedb_interface.driver
-            del self.typedb_interface
+        self.close_typedb_interface()
 
         self.get_logger().info(self.get_name() + ' :on_cleanup() is called.')
         return TransitionCallbackReturn.SUCCESS

--- a/ros_typedb/ros_typedb/ros_typedb_interface.py
+++ b/ros_typedb/ros_typedb/ros_typedb_interface.py
@@ -439,8 +439,23 @@ class ROSTypeDBInterface(Node):
 
         :return: transition result
         """
-        self.destroy_publisher(self.event_pub)
-        self.destroy_service(self.insert_query_service)
+        for service_name in ('query_service', 'delete_db_service'):
+            service = getattr(self, service_name, None)
+            if service is not None:
+                self.destroy_service(service)
+                delattr(self, service_name)
+
+        if getattr(self, 'event_pub', None) is not None:
+            self.destroy_publisher(self.event_pub)
+            del self.event_pub
+
+        typedb_interface = getattr(self, 'typedb_interface', None)
+        if typedb_interface is not None:
+            driver = getattr(typedb_interface, 'driver', None)
+            if driver is not None:
+                driver.close()
+                del typedb_interface.driver
+            del self.typedb_interface
 
         self.get_logger().info(self.get_name() + ' :on_cleanup() is called.')
         return TransitionCallbackReturn.SUCCESS

--- a/ros_typedb/ros_typedb/typedb_interface.py
+++ b/ros_typedb/ros_typedb/typedb_interface.py
@@ -257,7 +257,7 @@ class TypeDBInterface:
         def close_late_driver():
             thread.join()
             succeeded, result = result_queue.get()
-            if succeeded:
+            if succeeded and result is not None:
                 result.close()
 
         thread = threading.Thread(target=connect_driver_thread, daemon=True)

--- a/ros_typedb/test/test_ros_typedb_interface.py
+++ b/ros_typedb/test/test_ros_typedb_interface.py
@@ -16,6 +16,8 @@ from pathlib import Path
 import sys
 from threading import Event
 from threading import Thread
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import launch
 import launch_pytest
@@ -28,10 +30,12 @@ import pytest
 
 from rcl_interfaces.msg import ParameterType
 import rclpy
+from rclpy.lifecycle import TransitionCallbackReturn
 from rclpy.node import Node
 
 from ros_typedb.ros_typedb_interface import convert_attribute_dict_to_ros_msg
 from ros_typedb.ros_typedb_interface import fetch_result_to_ros_result_tree
+from ros_typedb.ros_typedb_interface import ROSTypeDBInterface
 
 from ros_typedb_msgs.msg import Attribute
 from ros_typedb_msgs.msg import IndexList
@@ -242,6 +246,40 @@ def test_ros_typedb_wrong_query(test_node, insert_query):
     insert_query_req.query_type = 100
     query_res = test_node.call_service(test_node.query_cli, insert_query_req)
     assert query_res.success is False
+
+
+def test_on_cleanup_destroys_ros_entities_and_closes_typedb_driver():
+    driver = MagicMock()
+    typedb_interface = SimpleNamespace(driver=driver)
+
+    event_pub = MagicMock()
+    query_service = MagicMock()
+    delete_db_service = MagicMock()
+
+    node = SimpleNamespace(
+        event_pub=event_pub,
+        query_service=query_service,
+        delete_db_service=delete_db_service,
+        typedb_interface=typedb_interface,
+        destroy_publisher=MagicMock(return_value=True),
+        destroy_service=MagicMock(return_value=True),
+        get_logger=MagicMock(return_value=MagicMock()),
+        get_name=MagicMock(return_value='ros_typedb'),
+    )
+
+    result = ROSTypeDBInterface.on_cleanup(node, None)
+
+    assert result == TransitionCallbackReturn.SUCCESS
+    node.destroy_publisher.assert_called_once_with(event_pub)
+    node.destroy_service.assert_any_call(query_service)
+    node.destroy_service.assert_any_call(delete_db_service)
+    assert node.destroy_service.call_count == 2
+    driver.close.assert_called_once_with()
+    assert not hasattr(node, 'event_pub')
+    assert not hasattr(node, 'query_service')
+    assert not hasattr(node, 'delete_db_service')
+    assert not hasattr(node, 'typedb_interface')
+    assert not hasattr(typedb_interface, 'driver')
 
 
 def test_convert_attribute_dict_to_ros_msg():

--- a/ros_typedb/test/test_ros_typedb_interface.py
+++ b/ros_typedb/test/test_ros_typedb_interface.py
@@ -248,6 +248,16 @@ def test_ros_typedb_wrong_query(test_node, insert_query):
     assert query_res.success is False
 
 
+def test_close_typedb_interface_closes_driver_and_clears_interface():
+    driver = MagicMock()
+    node = SimpleNamespace(typedb_interface=SimpleNamespace(driver=driver))
+
+    ROSTypeDBInterface.close_typedb_interface(node)
+
+    driver.close.assert_called_once_with()
+    assert node.typedb_interface is None
+
+
 def test_on_cleanup_destroys_ros_entities_and_closes_typedb_driver():
     driver = MagicMock()
     typedb_interface = SimpleNamespace(driver=driver)
@@ -278,8 +288,7 @@ def test_on_cleanup_destroys_ros_entities_and_closes_typedb_driver():
     assert not hasattr(node, 'event_pub')
     assert not hasattr(node, 'query_service')
     assert not hasattr(node, 'delete_db_service')
-    assert not hasattr(node, 'typedb_interface')
-    assert not hasattr(typedb_interface, 'driver')
+    assert node.typedb_interface is None
 
 
 def test_convert_attribute_dict_to_ros_msg():

--- a/ros_typedb/test/test_ros_typedb_interface.py
+++ b/ros_typedb/test/test_ros_typedb_interface.py
@@ -324,6 +324,9 @@ def test_on_cleanup_destroys_ros_entities_and_closes_typedb_driver():
         destroy_service=MagicMock(return_value=True),
         get_logger=MagicMock(return_value=MagicMock()),
         get_name=MagicMock(return_value='ros_typedb'),
+        close_typedb_interface=MagicMock(
+            side_effect=lambda: ROSTypeDBInterface.close_typedb_interface(node)
+        )
     )
 
     result = ROSTypeDBInterface.on_cleanup(node, None)
@@ -333,6 +336,7 @@ def test_on_cleanup_destroys_ros_entities_and_closes_typedb_driver():
     node.destroy_service.assert_any_call(query_service)
     node.destroy_service.assert_any_call(delete_db_service)
     assert node.destroy_service.call_count == 2
+    assert node.close_typedb_interface.call_count == 1
     driver.close.assert_called_once_with()
     assert not hasattr(node, 'event_pub')
     assert not hasattr(node, 'query_service')


### PR DESCRIPTION
### Motivation
- Ensure deterministic shutdown of TypeDB resources during the lifecycle `on_cleanup` transition instead of relying on `__del__` GC behavior. 
- Remove incorrect cleanup of a nonexistent service attribute and properly tear down ROS publisher and services to avoid resource leaks.

### Description
- Replace the incorrect `insert_query_service` cleanup with explicit destruction of both `query_service` and `delete_db_service` and removal of their attributes. (modified `ros_typedb/ros_typedb/ros_typedb_interface.py`)
- Destroy the lifecycle `event_pub` publisher and delete the `event_pub` attribute after destruction. (modified `ros_typedb/ros_typedb/ros_typedb_interface.py`)
- If a `typedb_interface` exists, explicitly close `typedb_interface.driver`, delete the driver attribute, and then delete `self.typedb_interface` to avoid GC-timing-dependent shutdown. (modified `ros_typedb/ros_typedb/ros_typedb_interface.py`)
- Add a regression unit test `test_on_cleanup_destroys_ros_entities_and_closes_typedb_driver` that verifies the publisher and services are destroyed, the TypeDB driver is closed, and cleanup-managed attributes are removed. (added to `ros_typedb/test/test_ros_typedb_interface.py`)

### Testing
- Successfully type-checked/compiled the modified files with `python3 -m py_compile ros_typedb/ros_typedb/ros_typedb_interface.py ros_typedb/test/test_ros_typedb_interface.py` which passed. 
- Ran `git diff --check` to validate there are no whitespace or diff issues which passed. 
- Added and attempted to execute the new pytest unit (`pytest -q ros_typedb/test/test_ros_typedb_interface.py::test_on_cleanup_destroys_ros_entities_and_closes_typedb_driver`), but it failed to collect because the execution environment is missing the ROS `launch` dependency (ModuleNotFoundError: No module named 'launch').

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dcc2452d0832cb47e2f4bbb10af3c)