### PR TITLE
fix: on_cleanup wrong service attr, leak delete_db_service, skip driver close

### DIFF
--- a/ros_typedb/ros_typedb/ros_typedb_interface.py
+++ b/ros_typedb/ros_typedb/ros_typedb_interface.py
@@ -440,7 +440,10 @@ class ROSTypeDBInterface(Node):
         :return: transition result
         """
         self.destroy_publisher(self.event_pub)
-        self.destroy_service(self.insert_query_service)
+        self.destroy_service(self.query_service)
+        self.destroy_service(self.delete_db_service)
+        if hasattr(self, 'typedb_interface'):
+            self.typedb_interface.driver.close()
 
         self.get_logger().info(self.get_name() + ' :on_cleanup() is called.')
         return TransitionCallbackReturn.SUCCESS


### PR DESCRIPTION
## Summary

- `on_cleanup` referenced `self.insert_query_service` which does not exist — raised `AttributeError` on every lifecycle cleanup transition, leaving both services alive
- `self.delete_db_service` was never destroyed in cleanup (leaked)
- The TypeDB driver connection was never closed (relied solely on GC via `__del__`)

## Changes

`ros_typedb/ros_typedb/ros_typedb_interface.py` — `on_cleanup` only:
- Fix attribute name: `insert_query_service` → `query_service`
- Add `self.destroy_service(self.delete_db_service)`
- Add `self.typedb_interface.driver.close()` guarded by `hasattr`

## Test plan

- [ ] `python3 -m py_compile ros_typedb/ros_typedb/ros_typedb_interface.py`
- [ ] Full suite via Docker: `colcon test --packages-select ros_typedb --event-handlers console_direct+`
- [ ] Confirm `test_ros_typedb_lc_states` passes (exercises configure → activate → cleanup path)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)