### PR TITLE
fix: get_aggregate result None guard and set success=True

### DIFF
--- a/ros_typedb/ros_typedb/ros_typedb_interface.py
+++ b/ros_typedb/ros_typedb/ros_typedb_interface.py
@@ -268,6 +268,10 @@ def get_aggregate_query_result_to_ros_msg(
     :return: converted query response.
     """
     response = Query.Response()
+
+    if query_result is None:
+        return response
+
     attr = Attribute()
     attr.value = set_query_result_value(
         query_result,
@@ -279,6 +283,7 @@ def get_aggregate_query_result_to_ros_msg(
     result_tree = ResultTree()
     result_tree.results.append(query_result_ros_msg)
     response.results.append(result_tree)
+    response.success = True
     return response
 
 


### PR DESCRIPTION
## Summary

`get_aggregate_query_result_to_ros_msg` had two bugs:

1. No `None` guard — when `get_aggregate_database` returns `None` (e.g., `count` over an empty match set), `type(None).__name__` is `'NoneType'`, which is absent from `_PARAM_TYPE_MAP`. `set_query_result_value` raised `ValueError`, crashing the service callback thread.
2. `response.success` was never set to `True`, so even a successful aggregate returned `success=False`.

## Changes

`ros_typedb/ros_typedb/ros_typedb_interface.py` — `get_aggregate_query_result_to_ros_msg` only:
- Add `if query_result is None: return response` guard at the top
- Add `response.success = True` before the return

## Test plan

- [ ] `python3 -m py_compile ros_typedb/ros_typedb/ros_typedb_interface.py`
- [ ] Full suite via Docker: `colcon test --packages-select ros_typedb --event-handlers console_direct+`
- [ ] Confirm `test_ros_typedb_get_aggregate_query` passes and returns correct `success=True`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)