### PR TITLE
fix: get_query_result_to_ros_msg UnboundLocalError on non-attribute variables

### DIFF
--- a/ros_typedb/ros_typedb/ros_typedb_interface.py
+++ b/ros_typedb/ros_typedb/ros_typedb_interface.py
@@ -252,7 +252,7 @@ def get_query_result_to_ros_msg(
                     typedb_attr.get_value(),
                     str(typedb_attr.get_type().get_value_type()))
                 query_result_ros.attribute = attr
-            result_tree.results.append(query_result_ros)
+                result_tree.results.append(query_result_ros)
         response.results.append(result_tree)
     response.success = True
     return response


### PR DESCRIPTION
## Summary

`result_tree.results.append(query_result_ros)` was outside the `if variable_value.is_attribute():` block:

- On the **first** iteration where the variable is an entity or relation: `query_result_ros` was unbound → `UnboundLocalError`
- On **subsequent** iterations: appended the stale result from the previous attribute assignment → silent data corruption

## Changes

`ros_typedb/ros_typedb/ros_typedb_interface.py` — `get_query_result_to_ros_msg` only:
- Move `result_tree.results.append(query_result_ros)` inside the `if variable_value.is_attribute():` block (one level of indentation added)
- Non-attribute columns in GET results are now silently skipped, which is the correct design intent

## Test plan

- [ ] `python3 -m py_compile ros_typedb/ros_typedb/ros_typedb_interface.py`
- [ ] Full suite via Docker: `colcon test --packages-select ros_typedb --event-handlers console_direct+`
- [ ] Confirm `test_ros_typedb_get_query` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)