### PR TITLE
feat: re-enable insert/delete event publishing

### DIFF
--- a/ros_typedb/ros_typedb/typedb_interface.py
+++ b/ros_typedb/ros_typedb/typedb_interface.py
@@ -510,7 +510,7 @@ class TypeDBInterface:
         return delete_data_event_wrapper
     # Events end
 
-    # @insert_data_event_
+    @insert_data_event_
     def insert_database(self, query: str) -> Iterator[ConceptMap] | None:
         """
         Perform insert query.
@@ -543,7 +543,7 @@ class TypeDBInterface:
                 'Error with update query! Exception retrieved: %s', err)
         return result
 
-    # @delete_data_event_
+    @delete_data_event_
     def delete_from_database(self, query: str) -> Literal[True] | None:
         """
         Perform delete query.

--- a/ros_typedb/test/test_ros_typedb_interface.py
+++ b/ros_typedb/test/test_ros_typedb_interface.py
@@ -222,8 +222,6 @@ def test_ros_typedb_insert_query(test_node, insert_query):
     assert query_res.success is True
 
 
-@pytest.mark.skip(
-    reason='Events deactivated')
 @pytest.mark.launch(fixture=generate_test_description)
 def test_ros_typedb_insert_event(insert_query):
     node = MakeTestNode()
@@ -266,8 +264,6 @@ def test_ros_typedb_delete_query(test_node, insert_query):
     assert match_query_res.results[0].results[0].attribute.value.integer_value == 0
 
 
-@pytest.mark.skip(
-    reason='Events deactivated')
 @pytest.mark.launch(fixture=generate_test_description)
 def test_ros_typedb_delete_event(test_node, insert_query):
     test_node.activate_ros_typedb()


### PR DESCRIPTION
## Summary

- Re-enables `@insert_data_event_` decorator on `insert_database`
- Re-enables `@delete_data_event_` decorator on `delete_from_database`
- Removes `@pytest.mark.skip(reason='Events deactivated')` from `test_ros_typedb_insert_event` and `test_ros_typedb_delete_event`

The event infrastructure (decorator functions, monkey-patches in `init_typedb_interface`, publisher creation, `publish_data_event` method) was never removed — only the two decorator applications were commented out in commit `3ea6012` ("🔥 not publishing events anymore", Nov 2023) with no explanation. All that was needed was to restore those two lines.

## Test plan

- [ ] `test_ros_typedb_insert_event` must pass (previously skipped)
- [ ] `test_ros_typedb_delete_event` must pass (previously skipped)
- [ ] All other existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)