### PR TITLE
feat: add error_message to Query.Response

### DIFF
--- a/ros_typedb/ros_typedb/ros_typedb_interface.py
+++ b/ros_typedb/ros_typedb/ros_typedb_interface.py
@@ -507,12 +507,14 @@ class ROSTypeDBInterface(Node):
             self.get_logger().warning(
                 'Query type {} not recognized'.format(req.query_type))
             response.success = False
+            response.error_message = f'Unknown query type: {req.query_type}'
             return response
 
         query_result = query_func(req.query)
         response = query_result_to_ros_msg(req.query_type, query_result)
         if query_result is None:
             response.success = False
+            response.error_message = self.typedb_interface.last_error
         else:
             response.success = True
         return response

--- a/ros_typedb/ros_typedb/typedb_interface.py
+++ b/ros_typedb/ros_typedb/typedb_interface.py
@@ -182,6 +182,7 @@ class TypeDBInterface:
         """
         self.logger = logging.getLogger()
         self._database_query_lock = Lock()
+        self.last_error: str = ''
         self._address = address
         self._driver_timeout_s = driver_timeout_s
         self._infer = infer
@@ -518,6 +519,7 @@ class TypeDBInterface:
         :param query: Query to be performed.
         :return: Query result, if query fails return None.
         """
+        self.last_error = ''
         result = None
         try:
             result = self.database_query(
@@ -525,6 +527,7 @@ class TypeDBInterface:
         except Exception as err:
             self.logger.warning(
                 'Error with insert query! Exception retrieved: %s', err)
+            self.last_error = str(err)
         return result
 
     def update_database(self, query: str) -> Iterator[ConceptMap] | None:
@@ -534,6 +537,7 @@ class TypeDBInterface:
         :param query: Query to be performed.
         :return: Query result, if query fails return None.
         """
+        self.last_error = ''
         result = None
         try:
             result = self.database_query(
@@ -541,6 +545,7 @@ class TypeDBInterface:
         except Exception as err:
             self.logger.warning(
                 'Error with update query! Exception retrieved: %s', err)
+            self.last_error = str(err)
         return result
 
     # @delete_data_event_
@@ -551,6 +556,7 @@ class TypeDBInterface:
         :param query: Query to be performed.
         :return: Query result, if query fails return None.
         """
+        self.last_error = ''
         result = None
         try:
             result = self.database_query(
@@ -558,16 +564,19 @@ class TypeDBInterface:
         except Exception as err:
             self.logger.warning(
                 'Error with delete query! Exception retrieved: %s', err)
+            self.last_error = str(err)
         return result
 
     def define_database(self, query: str) -> Literal[True] | None:
         """Perform define query."""
+        self.last_error = ''
         result = None
         try:
             result = self.database_query(
                 SessionType.SCHEMA, TransactionType.WRITE, 'define', query)
         except Exception as err:
             self.logger.warning('Error with define query! Exception retrieved: %s', err)
+            self.last_error = str(err)
         return result
 
     def fetch_database(
@@ -582,6 +591,7 @@ class TypeDBInterface:
             If None, uses the interface default policy.
         :return: Query result, if query fails return None.
         """
+        self.last_error = ''
         result = None
         try:
             options = TypeDBOptions()
@@ -597,6 +607,7 @@ class TypeDBInterface:
                 result = recursively_sort_dict(result)
         except Exception as err:
             self.logger.warning('Error with match query! Exception retrieved: %s', err)
+            self.last_error = str(err)
         return result
 
     def fetch_database_unordered(
@@ -626,6 +637,7 @@ class TypeDBInterface:
         :param query: Query to be performed.
         :return: Query result.
         """
+        self.last_error = ''
         result = None
         try:
             options = TypeDBOptions()
@@ -639,6 +651,7 @@ class TypeDBInterface:
         except Exception as err:
             self.logger.warning(
                 'Error with get query! Exception retrieved: %s', err)
+            self.last_error = str(err)
         return result
 
     def get_aggregate_database(self, query: str) -> int | float | None:
@@ -648,6 +661,7 @@ class TypeDBInterface:
         :param query: Query to be performed.
         :return: Query result.
         """
+        self.last_error = ''
         result = None
         try:
             options = TypeDBOptions()
@@ -661,6 +675,7 @@ class TypeDBInterface:
         except Exception as err:
             self.logger.warning(
                 'Error with get_aggregate query! Exception retrieved: %s', err)
+            self.last_error = str(err)
         return result
     # Read/write database end
 

--- a/ros_typedb_msgs/srv/Query.srv
+++ b/ros_typedb_msgs/srv/Query.srv
@@ -11,4 +11,5 @@ uint8 query_type
 string query
 ---
 bool success
+string error_message
 ros_typedb_msgs/ResultTree[] results


### PR DESCRIPTION
## Summary

- Adds `string error_message` to `Query.srv` response (after `bool success`)
- Adds `TypeDBInterface.last_error: str = ''` attribute, reset at the start of each DB method and populated with `str(err)` in each `except` block (`insert_database`, `update_database`, `delete_from_database`, `define_database`, `fetch_database`, `get_database`, `get_aggregate_database`)
- `query_service_cb` now sets `response.error_message = self.typedb_interface.last_error` on failure, or `f'Unknown query type: {req.query_type}'` for unrecognised query types

## Test plan

- [ ] Trigger a query failure (e.g., invalid TypeQL syntax) and assert `response.success is False` and `response.error_message` is non-empty
- [ ] Successful query: `response.error_message` is `''`
- [ ] Unknown `query_type`: `response.success is False` and `error_message` contains the type value

🤖 Generated with [Claude Code](https://claude.com/claude-code)